### PR TITLE
Move away from deprecated Web3 contract.deploy() method.

### DIFF
--- a/pymaker/__init__.py
+++ b/pymaker/__init__.py
@@ -138,7 +138,9 @@ class Contract:
         assert(isinstance(bytecode, str))
         assert(isinstance(args, list))
 
-        tx_hash = web3.eth.contract(abi=abi, bytecode=bytecode).deploy(transaction={'from': eth_utils.to_checksum_address(web3.eth.defaultAccount)}, args=args)
+        contract = web3.eth.contract(abi=abi, bytecode=bytecode)
+        tx_hash = contract.constructor(*args).transact(
+            transaction={'from': eth_utils.to_checksum_address(web3.eth.defaultAccount)})
         receipt = web3.eth.getTransactionReceipt(tx_hash)
         return Address(receipt['contractAddress'])
 

--- a/test.sh
+++ b/test.sh
@@ -5,3 +5,4 @@ sleep 5
 
 py.test --cov=pymaker --cov-report=term --cov-append tests/
 
+killall ganache.sh


### PR DESCRIPTION
This cleans up a bunch of warnings in pyexchange.  Also, updated test.sh to clean up the dangling ganache process.