### PR TITLE
Including the json filename in the password prompt

### DIFF
--- a/pymaker/keys.py
+++ b/pymaker/keys.py
@@ -54,7 +54,7 @@ def register_key_file(web3: Web3, key_file: str, pass_file: Optional[str] = None
             with open(pass_file) as pass_file_open:
                 read_pass = pass_file_open.read().replace("\n", "")
         else:
-            read_pass = getpass.getpass()
+            read_pass = getpass.getpass(prompt=f"Password for {key_file}: ")
 
         private_key = Account.decrypt(read_key, read_pass)
         register_private_key(web3, private_key)


### PR DESCRIPTION
This way it's easier to figure out which password shall we enter, as usually different bots will be using different accounts (and so different json files as well).