### PR TITLE
`force=True` flag added to `transact()` for skipping `eth_estimateGas`

### DIFF
--- a/pymaker/__init__.py
+++ b/pymaker/__init__.py
@@ -482,6 +482,27 @@ class Transact:
 
         return estimate
 
+    def simulate(self, from_address: Address):
+        """Simulate the transaction's execution
+
+        Will throw an exception if the transaction will fail.
+
+        Args:
+            from_address: Address to simulate sending the transaction from.
+        """
+        assert(isinstance(from_address, Address))
+
+        if self.contract is None:
+            return
+
+        if self.function_name is None:
+            self.web3.eth.call({**self._as_dict(self.extra), **{'from': from_address.address,
+                                                                'to': self.address.address,
+                                                                'data': self.parameters[0]}})
+
+        else:
+            self._contract_function().call({**self._as_dict(self.extra), **{'from': from_address.address}})
+
     def transact(self, **kwargs) -> Optional[Receipt]:
         """Executes the Ethereum transaction synchronously.
 

--- a/pymaker/__init__.py
+++ b/pymaker/__init__.py
@@ -536,10 +536,9 @@ class Transact:
         from_account = kwargs['from_address'].address if ('from_address' in kwargs) else self.web3.eth.defaultAccount
 
         # First we try to estimate the gas usage of the transaction. If gas estimation fails
-        # it means there is no point in sending the transaction, thus we fail instantly and
-        # do not increment the nonce. If the estimation is successful, we pass the calculated
-        # gas value (plus some `gas_buffer`) to the subsequent `transact` calls so it does not
-        # try to estimate it again.
+        # it means there is no point in sending the transaction. If the estimation is successful,
+        # we pass the calculated gas value (plus some `gas_buffer`, unless actual `gas` is specified)
+        # to the subsequent `transact` calls so it does not try to estimate it again.
         try:
             gas_estimate = self.estimated_gas(Address(from_account))
         except:

--- a/pymaker/__init__.py
+++ b/pymaker/__init__.py
@@ -558,8 +558,8 @@ class Transact:
         if len(unknown_kwargs) > 0:
             raise Exception(f"Unknown kwargs: {unknown_kwargs}")
 
-        # Get the from account.
-        from_account = kwargs['from_address'].address if ('from_address' in kwargs) else self.web3.eth.defaultAccount
+        # Get the from address.
+        from_address = kwargs['from_address'].address if ('from_address' in kwargs) else self.web3.eth.defaultAccount
 
         # First we try to either simulate the transaction execution, or estimate the gas usage
         # of the transaction (depending on whether `gas` kwarg is specified or not). If any of these fail
@@ -568,12 +568,12 @@ class Transact:
         # to estimate it again.
         try:
             if 'gas' in kwargs:
-                self.simulate(from_address=Address(from_account), gas=kwargs['gas'])
+                self.simulate(from_address=Address(from_address), gas=kwargs['gas'])
 
                 gas_estimate = None
 
             else:
-                gas_estimate = self.estimated_gas(Address(from_account))
+                gas_estimate = self.estimated_gas(Address(from_address))
         except:
             self.logger.warning(f"Transaction {self.name()} will fail, refusing to send ({sys.exc_info()[1]})")
             return None
@@ -600,7 +600,7 @@ class Transact:
         while True:
             seconds_elapsed = int(time.time() - initial_time)
 
-            if self.nonce is not None and self.web3.eth.getTransactionCount(from_account) > self.nonce:
+            if self.nonce is not None and self.web3.eth.getTransactionCount(from_address) > self.nonce:
                 # Check if any transaction sent so far has been mined (has a receipt).
                 # If it has, we return either the receipt (if if was successful) or `None`.
                 for _ in range(5):
@@ -636,12 +636,12 @@ class Transact:
                     with transaction_lock:
                         if self.nonce is None:
                             if self._is_parity():
-                                self.nonce = int(self.web3.manager.request_blocking("parity_nextNonce", [from_account]), 16)
+                                self.nonce = int(self.web3.manager.request_blocking("parity_nextNonce", [from_address]), 16)
 
                             else:
-                                self.nonce = self.web3.eth.getTransactionCount(from_account, block_identifier='pending')
+                                self.nonce = self.web3.eth.getTransactionCount(from_address, block_identifier='pending')
 
-                        tx_hash = self._func(from_account, gas, gas_price_value, self.nonce)
+                        tx_hash = self._func(from_address, gas, gas_price_value, self.nonce)
                         tx_hashes.append(tx_hash)
 
                     self.logger.info(f"Sent transaction {self.name()} with nonce={self.nonce}, gas={gas},"

--- a/tests/test_general2.py
+++ b/tests/test_general2.py
@@ -46,6 +46,19 @@ class TestTransact:
         # then
         assert estimate > 21000
 
+    def test_simulation(self):
+        # given
+        transact = self.token.transfer(self.second_address, Wad(500))
+        # expect
+        # [not to raise an exception]
+        transact.simulate(self.our_address)
+
+        # given
+        transact = self.token.transfer(self.second_address, Wad(1000001))
+        # expect
+        with pytest.raises(Exception):
+            transact.simulate(self.our_address)
+
     def test_can_only_execute_once(self):
         # given
         transact = self.token.transfer(self.second_address, Wad(500))
@@ -206,6 +219,13 @@ class TestTransact:
         transact = eth_transfer(self.web3, self.second_address, Wad.from_number(1.5))
         # then
         assert transact.estimated_gas(self.our_address) == 21000
+
+    def test_eth_transfer_simulation(self):
+        # given
+        transact = eth_transfer(self.web3, self.second_address, Wad.from_number(1.5))
+        # expect
+        # [not to raise an exception]
+        transact.simulate(self.our_address)
 
     def test_should_raise_exception_on_unknown_kwarg(self):
         # expect

--- a/tests/test_general2.py
+++ b/tests/test_general2.py
@@ -51,13 +51,24 @@ class TestTransact:
         transact = self.token.transfer(self.second_address, Wad(500))
         # expect
         # [not to raise an exception]
-        transact.simulate(self.our_address)
+        transact.simulate(from_address=self.our_address)
 
         # given
         transact = self.token.transfer(self.second_address, Wad(1000001))
         # expect
         with pytest.raises(Exception):
-            transact.simulate(self.our_address)
+            transact.simulate(from_address=self.our_address)
+
+    def test_simulation_should_take_gas_into_account(self):
+        # given
+        transact = self.token.transfer(self.second_address, Wad(500))
+
+        # expect
+        # [not to raise an exception]
+        transact.simulate(from_address=self.our_address, gas=100000)
+        # and
+        with pytest.raises(Exception):
+            transact.simulate(from_address=self.our_address, gas=25000)
 
     def test_can_only_execute_once(self):
         # given
@@ -225,7 +236,7 @@ class TestTransact:
         transact = eth_transfer(self.web3, self.second_address, Wad.from_number(1.5))
         # expect
         # [not to raise an exception]
-        transact.simulate(self.our_address)
+        transact.simulate(from_address=self.our_address)
 
     def test_should_raise_exception_on_unknown_kwarg(self):
         # expect

--- a/tests/test_general2.py
+++ b/tests/test_general2.py
@@ -38,6 +38,14 @@ class TestTransact:
         self.token = DSToken.deploy(self.web3, 'ABC')
         self.token.mint(Wad(1000000)).transact()
 
+    def test_gas_estimation(self):
+        # given
+        transact = self.token.transfer(self.second_address, Wad(500))
+        # when
+        estimate = transact.estimated_gas(self.our_address)
+        # then
+        assert estimate > 21000
+
     def test_can_only_execute_once(self):
         # given
         transact = self.token.transfer(self.second_address, Wad(500))
@@ -193,6 +201,12 @@ class TestTransact:
         # then
         assert eth_balance(self.web3, self.second_address) < initial_balance_second_address
         assert eth_balance(self.web3, self.third_address) == initial_balance_third_address + Wad.from_number(1.5)
+
+    def test_eth_transfer_gas_simulation(self):
+        # when
+        transact = eth_transfer(self.web3, self.second_address, Wad.from_number(1.5))
+        # then
+        assert transact.estimated_gas(self.our_address) == 21000
 
     def test_should_raise_exception_on_unknown_kwarg(self):
         # expect

--- a/tests/test_general2.py
+++ b/tests/test_general2.py
@@ -201,7 +201,7 @@ class TestTransact:
         assert eth_balance(self.web3, self.second_address) < initial_balance_second_address
         assert eth_balance(self.web3, self.third_address) == initial_balance_third_address + Wad.from_number(1.5)
 
-    def test_eth_transfer_gas_simulation(self):
+    def test_eth_transfer_gas_estimation(self):
         # when
         transact = eth_transfer(self.web3, self.second_address, Wad.from_number(1.5))
         # then

--- a/tests/test_general2.py
+++ b/tests/test_general2.py
@@ -145,6 +145,17 @@ class TestTransact:
         # then
         assert self.web3.eth.getTransaction(receipt.transaction_hash)['gas'] > 2500000
 
+    def test_forced_transaction(self):
+        # when
+        receipt = self.token.transfer(self.second_address, Wad(500)).transact(gas=129994, force=True)
+        # then
+        assert self.web3.eth.getTransaction(receipt.transaction_hash)['gas'] == 129994
+
+        # when
+        receipt = synchronize([self.token.transfer(self.second_address, Wad(500)).transact_async(gas=129994, force=True)])[0]
+        # then
+        assert self.web3.eth.getTransaction(receipt.transaction_hash)['gas'] == 129994
+
     def test_gas_and_gas_buffer_not_allowed_at_the_same_time(self):
         # expect
         with pytest.raises(Exception):
@@ -154,6 +165,15 @@ class TestTransact:
         with pytest.raises(Exception):
             synchronize([self.token.transfer(self.second_address, Wad(500)).transact_async(gas=129995,
                                                                                            gas_buffer=3000000)])
+
+    def test_force_without_specifying_gas_not_allowed(self):
+        # expect
+        with pytest.raises(Exception):
+            self.token.transfer(self.second_address, Wad(500)).transact(force=True)
+
+        # expect
+        with pytest.raises(Exception):
+            synchronize([self.token.transfer(self.second_address, Wad(500)).transact_async(force=True)])
 
     def test_custom_gas_price(self):
         # given

--- a/tests/test_general2.py
+++ b/tests/test_general2.py
@@ -126,7 +126,6 @@ class TestTransact:
         with pytest.raises(Exception):
             self.token.transfer(self.second_address, Wad(500)).transact(gas=129995, gas_buffer=3000000)
 
-    def test_gas_and_gas_buffer_not_allowed_at_the_same_time_async(self):
         # expect
         with pytest.raises(Exception):
             synchronize([self.token.transfer(self.second_address, Wad(500)).transact_async(gas=129995,


### PR DESCRIPTION
If we prefer performance to confidence that the transaction will succeed before sending it, `force=True` flag can be passed to `transact()` and `transact_async()`, together with the `gas` parameter, so that estimation via `eth_estimateGas` can be completely skipped.

If `gas` is passed, but `force=True` isn't present, a faster `eth_call` will be made instead of `eth_estimateGas`.