### PR TITLE
added EthToken class to token.py

### DIFF
--- a/pymaker/token.py
+++ b/pymaker/token.py
@@ -68,7 +68,7 @@ class ERC20Token(Contract):
 
     def total_supply(self) -> Wad:
         """Returns the total supply of the token.
-        
+
         Returns:
             The total supply of the token.
         """
@@ -335,3 +335,35 @@ class DSEthToken(ERC20Token):
 
     def __repr__(self):
         return f"DSEthToken('{self.address}')"
+
+
+class EthToken():
+    """Basic ETH token.
+
+        Attributes:
+         web3: An instance of `Web` from `web3.py`.
+         address: Ethereum address of the ERC20 token.
+    """
+
+    def __init__(self, web3: Web3, address: Address):
+        assert(isinstance(web3, Web3))
+        assert(isinstance(address, Address))
+
+        self.web3 = web3
+        self.address = address
+
+    def balance_of(self, address):
+        """Returns the ETH balance of a given Ethereum address.
+
+         Args:
+             address: The address to check the balance of.
+
+         Returns:
+             The ETH balance of the address specified.
+         """
+        assert(isinstance(address, Address))
+
+        return Wad(self.web3.eth.getBalance(address.address))
+
+
+


### PR DESCRIPTION
Airswap uses the regular ethtoken 0x000... this is not an ERC20 contract and therefore breaks when we attempt to pass it into our ERC20Token class.

This addition of the EthToken class allows us to get around this.