### PR TITLE
Fix test.sh not reporting py.test result code and ganache-cli process not killed

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,8 +1,12 @@
 #!/bin/sh
 
 ./ganache.sh &>/dev/null &
+GANACHE_PID=$!
 sleep 5
 
 py.test --cov=pymaker --cov-report=term --cov-append tests/
+TEST_RESULT=$?
 
-killall ganache.sh
+pkill -P $GANACHE_PID
+
+exit $TEST_RESULT


### PR DESCRIPTION
## Target Issues
fixes #100

## Descriptions
- Propagate py.test exit code so Travis CI can catch it
- In addition, `killall` didn't seem to pattern-match the process properly on Mac OS so I've made a few changes to fix it

## Proof-of-work (or more accurately: not-work)
https://travis-ci.com/Detoo/keeper/builds/118022194 (the test failed as expected)
