### PR TITLE
Fix pytest dependency problem with newer versions of attrs

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+attrs == 19.1.0
 codecov == 2.0.9
 mock == 2.0.0
 pytest == 3.3.0
@@ -7,3 +8,4 @@ pytest-mock == 1.6.3
 pytest-timeout == 1.2.1
 asynctest == 0.11.1
 Sphinx == 1.6.2
+


### PR DESCRIPTION
`pytest=3.3.0` requires `attrs>=17.2.0`. New virtualenvs now install attrs=19.2.0, which doesn't work with pytest=3.3.0.  Before any tests are run, the following error is produced:

```
Traceback (most recent call last):
  File "/home/ed/.local/bin/py.test", line 7, in <module>
    from pytest import main
  File "/home/ed/.local/lib/python3.6/site-packages/pytest.py", line 13, in <module>
    from _pytest.fixtures import fixture, yield_fixture
  File "/home/ed/.local/lib/python3.6/site-packages/_pytest/fixtures.py", line 839, in <module>
    class FixtureFunctionMarker(object):
  File "/home/ed/.local/lib/python3.6/site-packages/_pytest/fixtures.py", line 841, in FixtureFunctionMarker
    params = attr.ib(convert=attr.converters.optional(tuple))
TypeError: attrib() got an unexpected keyword argument 'convert'
```

The most recent compatible version is `attrs=19.1.0`, so pegging this dependency seems the most gentle resolution.