### PR TITLE
Wrapped public functions of DSChief

### DIFF
--- a/pymaker/governance.py
+++ b/pymaker/governance.py
@@ -190,6 +190,36 @@ class DSChief(Contract):
     def get_max_yays(self) -> int:
         return self._contract.call().MAX_YAYS()
 
+    def lock(self, amount: Wad) -> Transact:
+        assert isinstance(amount, Wad)
+
+        return Transact(self, self.web3, self.abi, self.address, self._contract, 'lock', [amount.value])
+
+    def free(self, amount: Wad) -> Transact:
+        assert isinstance(amount, Wad)
+
+        return Transact(self, self.web3, self.abi, self.address, self._contract, 'free', [amount.value])
+
+    def etch(self, yays: List) -> Transact:
+        assert isinstance(yays, List)
+
+        return Transact(self, self.web3, self.abi, self.address, self._contract, 'etch(address[])', [yays])
+
+    def vote_yays(self, yays: List) -> Transact:
+        assert isinstance(yays, List)
+
+        return Transact(self, self.web3, self.abi, self.address, self._contract, 'vote(address[])', [yays])
+
+    def vote_etch(self, etch: Etch) -> Transact:
+        assert isinstance(etch, Etch)
+
+        return Transact(self, self.web3, self.abi, self.address, self._contract, 'vote(bytes32)', [etch.slate])
+
+    def lift(self, whom: Address) -> Transact:
+        assert isinstance(whom, Address)
+
+        return Transact(self, self.web3, self.abi, self.address, self._contract, 'lift', [whom.address])
+
     def past_etch(self, number_of_past_blocks: int, event_filter: dict = None) -> List[Etch]:
         """Synchronously retrieve past Etch events.
 

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -55,14 +55,15 @@ class TestDSChief:
         isinstance(mcd, DssDeployment)
         isinstance(our_address, Address)
 
+        prevBalance = mcd.mkr.balance_of(our_address)
         amount = Wad.from_number(1000)
         mint_mkr(mcd.mkr, our_address, amount)
-        assert mcd.mkr.balance_of(our_address) == amount
+        assert mcd.mkr.balance_of(our_address) == amount + prevBalance
 
         # Lock MKR in DS-Chief
         assert mcd.mkr.approve(mcd.ds_chief.address).transact(from_address=our_address)
         assert mcd.ds_chief.lock(amount).transact(from_address=our_address)
-        assert mcd.mkr.balance_of(our_address) == Wad(0)
+        assert mcd.mkr.balance_of(our_address) == prevBalance
 
         # Vote for our address
         assert mcd.ds_chief.vote_yays([our_address.address]).transact(from_address=our_address)


### PR DESCRIPTION
DSChief extends DSChiefApprovals and the public functions therein:
- `lock(uint)`
- `free(uint)`
- `etch(address[])`
- `vote(address[])`
- `vote(bytes32)`
- `lift(address)`

This PR wraps these functions as well as an integration test, covering all but `free(uint)`. As described in the test's comment, the `free()` invocation is reverting because `our_address` needs to give ds-chief approval to move/burn IOU tokens before freeing MKR. Can fix in one of two ways:
1. Need to add IOU (ds-token) to DssDeployment
2. Look for a "mint" event to determine the address of the IOU token when locking MKR

Ref: https://github.com/dapphub/ds-chief/blob/master/src/chief.sol#L65

I'll be using the `pymaker.governance.DSChief` class in https://github.com/makerdao/chief-keeper