### PR TITLE
Update boolean exposed via filter_thread object

### DIFF
--- a/pymaker/__init__.py
+++ b/pymaker/__init__.py
@@ -62,7 +62,7 @@ def all_filter_threads_alive() -> bool:
 def filter_thread_alive(filter_thread) -> bool:
     # it's a wicked way of detecting whether a web3.py filter is still working
     # but unfortunately I wasn't able to find any other one
-    return hasattr(filter_thread, '_args') and hasattr(filter_thread, '_kwargs') or not filter_thread.running
+    return hasattr(filter_thread, '_args') and hasattr(filter_thread, '_kwargs') or not filter_thread.is_alive()
 
 
 def stop_all_filter_threads():


### PR DESCRIPTION
We have a keeper lifecycle that’s failing due to a missing `running` attribute on a Thread object: `AttributeError: 'Thread' object has no attribute 'running’`. On the same line that it’s failing, `pymaker` tries to detect when a web3 filter isn’t working, but it assumes that `running` is present. 

As suggested by @grandizzy, it looks more like a general issue where `filter_thread.running` should be replaced with `filter_thread.is_alive()`. 

Unit tests from `tests/test_lifecycle` all pass, and as a mainnet integration test, we've run the `chief-keeper` for a couple weeks with a modified `pymaker` without issue. 