### PR TITLE
Resolve issue with token.name() and token.symbol()

### DIFF
--- a/pymaker/deployment.py
+++ b/pymaker/deployment.py
@@ -319,23 +319,17 @@ class DssDeployment:
 
         network = DssDeployment.NETWORKS.get(web3.net.version, "testnet")
 
-        cwd = os.path.dirname(os.path.realpath(__file__))
-        addresses_path = os.path.join(cwd, "../config", f"{network}-addresses.json")
-        if not os.path.isfile(addresses_path):
-            raise FileNotFoundError("Network is not yet supported")
-
-        return DssDeployment.from_json(web3=web3, conf=open(addresses_path, "r").read())
+        return DssDeployment.from_network(web3=web3, network=network)
 
     @staticmethod
     def from_network(web3: Web3, network: str):
-        warnings.warn(
-            "this method will be removed, use DssDeployment.from_node(web3) instead",
-            DeprecationWarning
-        )
         assert isinstance(web3, Web3)
         assert isinstance(network, str)
 
-        return DssDeployment.from_node(web3=web3)
+        cwd = os.path.dirname(os.path.realpath(__file__))
+        addresses_path = os.path.join(cwd, "../config", f"{network}-addresses.json")
+
+        return DssDeployment.from_json(web3=web3, conf=open(addresses_path, "r").read())
 
     def approve_dai(self, usr: Address):
         """

--- a/pymaker/token.py
+++ b/pymaker/token.py
@@ -50,9 +50,9 @@ class ERC20Token(Contract):
         contract_with_bytes32 = self._get_contract(self.web3, abi_with_bytes32, self.address)
 
         try:
-            return contract_with_string.name().call()
+            return contract_with_string.functions.name().call()
         except:
-            return str(contract_with_bytes32.name().call(), "utf-8").strip('\x00')
+            return str(contract_with_bytes32.functions.name().call(), "utf-8").strip('\x00')
 
     def symbol(self) -> str:
         abi_with_string = json.loads("""[{"constant":true,"inputs":[],"name":"symbol","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"}]""")
@@ -62,7 +62,7 @@ class ERC20Token(Contract):
         contract_with_bytes32 = self._get_contract(self.web3, abi_with_bytes32, self.address)
 
         try:
-            return contract_with_string.symbol().call()
+            return contract_with_string.functions.symbol().call()
         except:
             return str(contract_with_bytes32.functions.symbol().call(), "utf-8").strip('\x00')
 

--- a/tests/test_dss.py
+++ b/tests/test_dss.py
@@ -28,7 +28,7 @@ from pymaker.dss import Vat, Vow, Cat, Ilk, Urn, Jug, GemJoin, DaiJoin, Collater
 from pymaker.feed import DSValue
 from pymaker.numeric import Wad, Ray, Rad
 from pymaker.oracles import OSM
-from pymaker.token import DSToken, DSEthToken
+from pymaker.token import DSToken, DSEthToken, ERC20Token
 from tests.conftest import validate_contracts_loaded
 
 
@@ -248,6 +248,13 @@ class TestConfig:
     def test_from_node(self, web3: Web3):
         mcd_testnet = DssDeployment.from_node(web3)
         validate_contracts_loaded(mcd_testnet)
+
+    def test_collaterals(self, mcd):
+        for collateral in mcd.collaterals.values():
+            assert isinstance(collateral.gem, ERC20Token)
+            assert len(collateral.ilk.name) > 0
+            assert len(collateral.gem.name()) > 0
+            assert len(collateral.gem.symbol()) > 0
 
     def test_account_transfers(self, web3: Web3, mcd, our_address, other_address):
         print(mcd.collaterals)

--- a/tests/test_dss.py
+++ b/tests/test_dss.py
@@ -251,10 +251,14 @@ class TestConfig:
 
     def test_collaterals(self, mcd):
         for collateral in mcd.collaterals.values():
+            assert isinstance(collateral.ilk, Ilk)
             assert isinstance(collateral.gem, ERC20Token)
             assert len(collateral.ilk.name) > 0
             assert len(collateral.gem.name()) > 0
             assert len(collateral.gem.symbol()) > 0
+            assert collateral.adapter is not None
+            assert collateral.flipper is not None
+            assert collateral.pip is not None
 
     def test_account_transfers(self, web3: Web3, mcd, our_address, other_address):
         print(mcd.collaterals)


### PR DESCRIPTION
Added mcd tests to ensure it works for all collaterals.

@grandizzy I resurrected `DssDeployment.from_network`, because I find it taxing to repeatedly swap out JSON configs whenever I switch to a nonstandard set of contracts.  I agree we should point users to `DssDeployment.from_node`, but this feature is very useful to me.

Confirmed travis is happy with this.