### PR TITLE
Updated approval functions to take gas strategy

### DIFF
--- a/pymaker/approval.py
+++ b/pymaker/approval.py
@@ -18,6 +18,7 @@
 import logging
 
 from pymaker import Address, Contract
+from pymaker import Transact
 from pymaker.numeric import Wad
 from pymaker.token import ERC20Token
 from pymaker.transactional import TxManager
@@ -80,13 +81,15 @@ def hope_directly(**kwargs):
         address_to_check = kwargs['from_address'] if 'from_address' in kwargs else Address(
             token.web3.eth.defaultAccount)
 
-        transact_args = {'from': address_to_check.address}
-
         move_contract = Contract._get_contract(web3=token.web3, abi=move_abi, address=token.address)
         if move_contract.functions.can(address_to_check.address, spender_address.address).call() is False:
             logger = logging.getLogger()
             logger.info(f"Approving {spender_name} ({spender_address}) to move our {token.address} directly")
-            if not move_contract.functions.hope(spender_address.address).transact(transact_args):
+
+            hope = Transact(move_contract, move_contract.web3, move_contract.abi, Address(move_contract.address),
+                            move_contract, 'hope', [spender_address.address])
+
+            if not hope.transact(**kwargs):
                 raise RuntimeError("Approval failed!")
 
     return approval_function

--- a/pymaker/auctions.py
+++ b/pymaker/auctions.py
@@ -83,7 +83,7 @@ class AuctionContract(Contract):
         """
         return Address(self._contract.functions.vat().call())
 
-    def approve(self, source: Address, approval_function, **kwargs):
+    def approve(self, source: Address, approval_function):
         """Approve the auction to access our collateral, Dai, or MKR so we can participate in auctions.
 
         For available approval functions (i.e. approval modes) see `directly` and `hope_directly`
@@ -98,7 +98,7 @@ class AuctionContract(Contract):
         assert(callable(approval_function))
 
         approval_function(token=ERC20Token(web3=self.web3, address=source),
-                          spender_address=self.address, spender_name=self.__class__.__name__, **kwargs)
+                          spender_address=self.address, spender_name=self.__class__.__name__)
 
     def active_auctions(self) -> list:
         active_auctions = []

--- a/pymaker/deployment.py
+++ b/pymaker/deployment.py
@@ -33,6 +33,7 @@ from pymaker.etherdelta import EtherDelta
 from pymaker.dss import Vat, Spotter, Vow, Jug, Cat, Collateral, DaiJoin, Ilk, GemJoin, Pot
 from pymaker.proxy import ProxyRegistry, DssProxyActionsDsr
 from pymaker.feed import DSValue
+from pymaker.gas import DefaultGasPrice
 from pymaker.governance import DSPause, DSChief
 from pymaker.numeric import Wad, Ray
 from pymaker.oasis import MatchingMarket
@@ -331,7 +332,7 @@ class DssDeployment:
 
         return DssDeployment.from_json(web3=web3, conf=open(addresses_path, "r").read())
 
-    def approve_dai(self, usr: Address):
+    def approve_dai(self, usr: Address, **kwargs):
         """
         Allows the user to draw Dai from and repay Dai to their CDPs.
 
@@ -340,8 +341,10 @@ class DssDeployment:
         """
         assert isinstance(usr, Address)
 
-        self.dai_adapter.approve(approval_function=hope_directly(from_address=usr), source=self.vat.address)
-        self.dai.approve(self.dai_adapter.address).transact(from_address=usr)
+        gas_price = kwargs['gas_price'] if 'gas_price' in kwargs else DefaultGasPrice()
+        self.dai_adapter.approve(approval_function=hope_directly(from_address=usr, gas_price=gas_price),
+                                 source=self.vat.address)
+        self.dai.approve(self.dai_adapter.address).transact(from_address=usr, gas_price=gas_price)
 
     def active_auctions(self) -> dict:
         flips = {}


### PR DESCRIPTION
I had to rework `hope_directly` to use `pymaker.Transact`.

To test, I used the following code, with commented gas prices observed from etherscan:
```
# Testing gas strategy

mcd.approve_dai(our_address)                                          # 16.5 Gwei 16.5 Gwei
collateral.approve(our_address)                                       # 16.5 Gwei 16.5 Gwei
from pymaker.approval import directly, hope_directly
mcd.flopper.approve(mcd.flopper.vat(), hope_directly())               # 14.63 Gwei

from pymaker.gas import FixedGasPrice
gas = FixedGasPrice(39*1000000000)
mcd.approve_dai(our_address, gas_price=gas)                           # 39 Gwei
collateral.approve(our_address, gas_price=gas)
mcd.flopper.approve(mcd.flopper.vat(), hope_directly(gas_price=gas))  # 39 Gwei
```