### PR TITLE
Improve pymaker handling of transaction replacement

### DIFF
--- a/pymaker/__init__.py
+++ b/pymaker/__init__.py
@@ -418,6 +418,12 @@ class Transact:
         else:
             return gas_estimate + 100000
 
+    def _gas_replacement_bump(self) -> float:
+        if self._is_parity():
+            return 1.125
+        else:
+            return 1.1
+
     def _func(self, from_account: str, gas: int, gas_price: Optional[int], nonce: Optional[int]):
         gas_price_dict = {'gasPrice': gas_price} if gas_price is not None else {}
         nonce_dict = {'nonce': nonce} if nonce is not None else {}
@@ -614,10 +620,10 @@ class Transact:
 
             # Send a transaction if:
             # - no transaction has been sent yet, or
-            # - the gas price requested has changed since the last transaction has been sent
+            # - the requested gas price has changed enough since the last transaction has been sent
             gas_price_value = gas_price.get_gas_price(seconds_elapsed)
             if len(tx_hashes) == 0 or ((gas_price_value is not None) and (gas_price_last is not None) and
-                                           (gas_price_value > gas_price_last * 1.1)):
+                                           (gas_price_value > gas_price_last * self._gas_replacement_bump())):
                 gas_price_last = gas_price_value
 
                 try:

--- a/pymaker/util.py
+++ b/pymaker/util.py
@@ -43,6 +43,7 @@ def http_response_summary(response) -> str:
     return f"{response.status_code} {response.reason} ({text})"
 
 
+# CAUTION: Used by Transact class, this breaks applications running their own asyncio event loop.
 def synchronize(futures) -> list:
     if len(futures) > 0:
         loop = asyncio.new_event_loop()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytz == 2017.3
-git+git://github.com/ethereum/web3.py.git@master#egg=web3.py
+git+git://github.com/EdNoepel/web3.py.git@master#egg=web3.py
 requests == 2.22.0
 eth-keys<0.3.0,>=0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytz == 2017.3
-web3 == 5.6.0
+git+git://github.com/ethereum/web3.py.git@master#egg=web3.py
 requests == 2.22.0
 eth-keys<0.3.0,>=0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytz == 2017.3
-git+git://github.com/EdNoepel/web3.py.git@master#egg=web3.py
+web3 == 5.6.0
 requests == 2.22.0
 eth-keys<0.3.0,>=0.2.1

--- a/tests/manual_test_async_tx.py
+++ b/tests/manual_test_async_tx.py
@@ -1,0 +1,102 @@
+# This file is part of Maker Keeper Framework.
+#
+# Copyright (C) 2020 EdNoepel
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+import logging
+import sys
+import threading
+import time
+from web3 import Web3, HTTPProvider
+
+from pymaker import Address
+from pymaker.deployment import DssDeployment
+from pymaker.gas import FixedGasPrice
+from pymaker.keys import register_keys
+from pymaker.numeric import Wad
+
+logging.basicConfig(format='%(asctime)-15s %(levelname)-8s %(message)s', level=logging.DEBUG)
+# reduce logspew
+logging.getLogger('urllib3').setLevel(logging.INFO)
+logging.getLogger("web3").setLevel(logging.INFO)
+logging.getLogger("asyncio").setLevel(logging.INFO)
+logging.getLogger("requests").setLevel(logging.INFO)
+
+endpoint_uri = f"https://parity0.kovan.makerfoundation.com:8545"
+web3 = Web3(HTTPProvider(endpoint_uri=endpoint_uri, request_kwargs={"timeout": 60}))
+web3.eth.defaultAccount = sys.argv[1]   # ex: 0x0000000000000000000000000000000aBcdef123
+register_keys(web3, [sys.argv[2]])      # ex: key_file=~keys/default-account.json,pass_file=~keys/default-account.pass
+
+mcd = DssDeployment.from_node(web3)
+our_address = Address(web3.eth.defaultAccount)
+
+collateral = mcd.collaterals['ETH-A']
+ilk = collateral.ilk
+collateral.approve(our_address)
+
+GWEI = 1000000000
+
+
+class TestApp:
+    def __init__(self):
+        self.wrap_amount = Wad(10)
+
+    def main(self):
+        self.startup()
+        self.test_replacement()
+        self.shutdown()
+
+    def startup(self):
+        logging.info(f"Wrapping {self.wrap_amount} ETH")
+        assert collateral.gem.deposit(self.wrap_amount).transact()
+
+    def test_replacement(self):
+        first_tx = collateral.adapter.join(our_address, Wad(4))
+        logging.info(f"Submitting first TX with gas price deliberately too low")
+        self._run_future(first_tx.transact_async(gas_price=FixedGasPrice(1000)))
+        time.sleep(0.3)
+
+        second_tx = collateral.adapter.join(our_address, Wad(6))
+        logging.info(f"Replacing first TX with legitimate gas price")
+        self._run_future(second_tx.transact_async(replace=first_tx, gas_price=FixedGasPrice(2*GWEI)))
+        time.sleep(0.3)
+
+    def shutdown(self):
+        time.sleep(6)
+        logging.info(f"Exiting {ilk.name} from our urn")
+        # balance = mcd.vat.gem(ilk, our_address)
+        # assert collateral.adapter.exit(our_address, balance).transact()
+        assert collateral.adapter.exit(our_address, Wad(6)).transact()
+        logging.info(f"Balance is {mcd.vat.gem(ilk, our_address)} {ilk.name}")
+        logging.info(f"Unwrapping {self.wrap_amount} ETH")
+        assert collateral.gem.withdraw(self.wrap_amount).transact()
+
+    @staticmethod
+    def _run_future(future):
+        def worker():
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                asyncio.get_event_loop().run_until_complete(future)
+            finally:
+                loop.close()
+
+        thread = threading.Thread(target=worker, daemon=True)
+        thread.start()
+
+
+if __name__ == '__main__':
+    TestApp().main()

--- a/tests/manual_test_async_tx.py
+++ b/tests/manual_test_async_tx.py
@@ -20,6 +20,7 @@ import logging
 import sys
 import threading
 import time
+
 from web3 import Web3, HTTPProvider
 
 from pymaker import Address
@@ -35,7 +36,7 @@ logging.getLogger("web3").setLevel(logging.INFO)
 logging.getLogger("asyncio").setLevel(logging.INFO)
 logging.getLogger("requests").setLevel(logging.INFO)
 
-endpoint_uri = f"https://parity0.kovan.makerfoundation.com:8545"
+endpoint_uri = f"https://localhost:8545"
 web3 = Web3(HTTPProvider(endpoint_uri=endpoint_uri, request_kwargs={"timeout": 60}))
 web3.eth.defaultAccount = sys.argv[1]   # ex: 0x0000000000000000000000000000000aBcdef123
 register_keys(web3, [sys.argv[2]])      # ex: key_file=~keys/default-account.json,pass_file=~keys/default-account.pass
@@ -55,6 +56,10 @@ class TestApp:
         self.wrap_amount = Wad(10)
 
     def main(self):
+        # tx_hash = '0x0e77dba683f10aee57114f6a753c33b7df5a2a99e63d7a1805e9e81f5694a917'
+        # encoded = Web3.toBytes(hexstr=tx_hash)
+        # assert len(encoded) == 32
+        # print(encoded)
         self.startup()
         self.test_replacement()
         self.shutdown()
@@ -67,15 +72,14 @@ class TestApp:
         first_tx = collateral.adapter.join(our_address, Wad(4))
         logging.info(f"Submitting first TX with gas price deliberately too low")
         self._run_future(first_tx.transact_async(gas_price=FixedGasPrice(1000)))
-        time.sleep(0.3)
+        time.sleep(2)
 
         second_tx = collateral.adapter.join(our_address, Wad(6))
         logging.info(f"Replacing first TX with legitimate gas price")
-        self._run_future(second_tx.transact_async(replace=first_tx, gas_price=FixedGasPrice(2*GWEI)))
-        time.sleep(0.3)
+        second_tx.transact(replace=first_tx, gas_price=FixedGasPrice(2*GWEI))
+        # time.sleep(6)
 
     def shutdown(self):
-        time.sleep(6)
         logging.info(f"Exiting {ilk.name} from our urn")
         # balance = mcd.vat.gem(ilk, our_address)
         # assert collateral.adapter.exit(our_address, balance).transact()

--- a/tests/manual_test_async_tx.py
+++ b/tests/manual_test_async_tx.py
@@ -56,10 +56,6 @@ class TestApp:
         self.wrap_amount = Wad(10)
 
     def main(self):
-        # tx_hash = '0x0e77dba683f10aee57114f6a753c33b7df5a2a99e63d7a1805e9e81f5694a917'
-        # encoded = Web3.toBytes(hexstr=tx_hash)
-        # assert len(encoded) == 32
-        # print(encoded)
         self.startup()
         self.test_replacement()
         self.shutdown()
@@ -77,7 +73,6 @@ class TestApp:
         second_tx = collateral.adapter.join(our_address, Wad(6))
         logging.info(f"Replacing first TX with legitimate gas price")
         second_tx.transact(replace=first_tx, gas_price=FixedGasPrice(2*GWEI))
-        # time.sleep(6)
 
     def shutdown(self):
         logging.info(f"Exiting {ilk.name} from our urn")

--- a/tests/manual_test_tx_queue.py
+++ b/tests/manual_test_tx_queue.py
@@ -1,0 +1,104 @@
+# This file is part of Maker Keeper Framework.
+#
+# Copyright (C) 2020 EdNoepel
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+import logging
+import requests
+import sys
+import threading
+import time
+
+from web3 import Web3, HTTPProvider
+
+from pymaker import Address
+from pymaker.deployment import DssDeployment
+from pymaker.gas import FixedGasPrice
+from pymaker.keys import register_keys
+from pymaker.numeric import Wad
+
+logging.basicConfig(format='%(asctime)-15s %(levelname)-8s %(message)s', level=logging.DEBUG)
+# reduce logspew
+logging.getLogger('urllib3').setLevel(logging.INFO)
+logging.getLogger("web3").setLevel(logging.INFO)
+logging.getLogger("asyncio").setLevel(logging.INFO)
+logging.getLogger("requests").setLevel(logging.INFO)
+
+# requests.adapters.DEFAULT_POOLSIZE = 100
+endpoint_uri = f"https://localhost:8545"
+web3 = Web3(HTTPProvider(endpoint_uri=endpoint_uri,
+                         request_kwargs={"timeout": 60},
+                         session_kwargs={"pool_connections": 50, "pool_maxsize": 50}))
+web3.eth.defaultAccount = sys.argv[1]   # ex: 0x0000000000000000000000000000000aBcdef123
+register_keys(web3, [sys.argv[2]])      # ex: key_file=~keys/default-account.json,pass_file=~keys/default-account.pass
+
+mcd = DssDeployment.from_node(web3)
+our_address = Address(web3.eth.defaultAccount)
+
+collateral = mcd.collaterals['ETH-A']
+ilk = collateral.ilk
+collateral.approve(our_address)
+
+GWEI = 1000000000
+
+
+class TestApp:
+    def __init__(self):
+        self.wrap_amount = Wad(1000)
+        self.joined = Wad(0)
+
+    def main(self):
+        self.startup()
+        self.submit_multiple_txs()
+        self.shutdown()
+
+    def startup(self):
+        logging.info(f"Wrapping {self.wrap_amount} ETH")
+        assert collateral.gem.deposit(self.wrap_amount).transact()
+
+    def submit_multiple_txs(self):
+        amount_to_join = Wad(3)
+        for i in range(1, 11):
+            join = collateral.adapter.join(our_address, amount_to_join)
+            self._run_future(join.transact_async(gas_price=FixedGasPrice(int(1.22*GWEI))))
+            self.joined += amount_to_join
+
+    def shutdown(self):
+        time.sleep(9)
+        logging.info(f"Exiting {ilk.name} from our urn")
+        balance = mcd.vat.gem(ilk, our_address)
+        assert collateral.adapter.exit(our_address, balance).transact()
+        # assert collateral.adapter.exit(our_address, self.joined).transact()
+        logging.info(f"Balance is {mcd.vat.gem(ilk, our_address)} {ilk.name}")
+        logging.info(f"Unwrapping {self.wrap_amount} ETH")
+        assert collateral.gem.withdraw(self.wrap_amount).transact()
+
+    @staticmethod
+    def _run_future(future):
+        def worker():
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                asyncio.get_event_loop().run_until_complete(future)
+            finally:
+                loop.close()
+
+        thread = threading.Thread(target=worker, daemon=True)
+        thread.start()
+
+
+if __name__ == '__main__':
+    TestApp().main()


### PR DESCRIPTION
- gracefully exit the original tx's event loop and prevent it from logging a warning after it is replaced
- update the gas replacement threshold for parity (see https://github.com/openethereum/openethereum/blob/e69539357f50d20bff51df28c556af8663552eec/miner/src/pool/scoring.rs#L38)