### PR TITLE
Created new gas strategy

### DIFF
--- a/pymaker/gas.py
+++ b/pymaker/gas.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import math
 from typing import Optional
 
 
@@ -104,14 +105,15 @@ class FixedGasPrice(GasPrice):
 class IncreasingGasPrice(GasPrice):
     """Constantly increasing gas price.
 
-    Start with `initial_price`, then increase it by `increase_by` every `every_secs` seconds
-    until the transaction gets confirmed. There is no upper limit.
+    Start with `initial_price`, then increase it by fixed amount `increase_by` every `every_secs` seconds
+    until the transaction gets confirmed. There is an optional upper limit.
 
     Attributes:
         initial_price: The initial gas price in Wei i.e. the price the transaction
             is originally sent with.
         increase_by: Gas price increase in Wei, which will happen every `every_secs` seconds.
         every_secs: Gas price increase interval (in seconds).
+        max_price: Optional upper limit.
     """
     def __init__(self, initial_price: int, increase_by: int, every_secs: int, max_price: Optional[int]):
         assert(isinstance(initial_price, int))
@@ -137,3 +139,45 @@ class IncreasingGasPrice(GasPrice):
             result = min(result, self.max_price)
 
         return result
+
+
+class GeometricGasPrice(GasPrice):
+    """Geometrically increasing gas price.
+
+    Start with `initial_price`, then increase it every 'every_secs' seconds by a fixed coefficient.
+    Coefficient defaults to 1.125 (12.5%), the minimum increase for Parity to replace a transaction.
+    Coefficient can be adjusted, and there is an optional upper limit.
+
+    Attributes:
+        initial_price: The initial gas price in Wei i.e. the price the transaction is originally sent with.
+        every_secs: Gas price increase interval (in seconds).
+        coefficient: Gas price multiplier, defaults to 1.125.
+        max_price: Optional upper limit, defaults to None.
+    """
+    def __init__(self, initial_price: int, every_secs: int, coefficient=1.125, max_price: Optional[int] = None):
+        assert (isinstance(initial_price, int))
+        assert (isinstance(every_secs, int))
+        assert (isinstance(max_price, int) or max_price is None)
+        assert (initial_price > 0)
+        assert (every_secs > 0)
+        assert (coefficient > 0)
+        if max_price is not None:
+            assert(max_price > 0)
+
+        self.initial_price = initial_price
+        self.every_secs = every_secs
+        self.coefficient = coefficient
+        self.max_price = max_price
+
+    def get_gas_price(self, time_elapsed: int) -> Optional[int]:
+        assert(isinstance(time_elapsed, int))
+
+        if time_elapsed < self.every_secs:
+            return self.initial_price
+        result = self.initial_price
+        for second in range(math.floor(time_elapsed/self.every_secs)):
+            result *= self.coefficient
+        if self.max_price is not None:
+            result = min(result, self.max_price)
+
+        return math.ceil(result)

--- a/tests/test_gas.py
+++ b/tests/test_gas.py
@@ -17,7 +17,7 @@
 
 import pytest
 
-from pymaker.gas import DefaultGasPrice, FixedGasPrice, IncreasingGasPrice, GasPrice
+from pymaker.gas import DefaultGasPrice, FixedGasPrice, GasPrice, GeometricGasPrice, IncreasingGasPrice
 
 
 class TestGasPrice:
@@ -132,3 +132,77 @@ class TestIncreasingGasPrice:
 
         with pytest.raises(Exception):
             IncreasingGasPrice(1000, 1000, 60, -1)
+
+
+class TestGeometricGasPrice:
+    def test_gas_price_should_increase_with_time(self):
+        # given
+        geometric_gas_price = GeometricGasPrice(100, 10)
+
+        # expect
+        assert geometric_gas_price.get_gas_price(0) == 100
+        assert geometric_gas_price.get_gas_price(1) == 100
+        assert geometric_gas_price.get_gas_price(10) == 113
+        assert geometric_gas_price.get_gas_price(15) == 113
+        assert geometric_gas_price.get_gas_price(20) == 127
+        assert geometric_gas_price.get_gas_price(30) == 143
+        assert geometric_gas_price.get_gas_price(50) == 181
+        assert geometric_gas_price.get_gas_price(100) == 325
+
+    def test_gas_price_should_obey_max_value(self):
+        # given
+        geometric_gas_price = GeometricGasPrice(1000, 60, 1.125, 2500)
+
+        # expect
+        assert geometric_gas_price.get_gas_price(0) == 1000
+        assert geometric_gas_price.get_gas_price(1) == 1000
+        assert geometric_gas_price.get_gas_price(59) == 1000
+        assert geometric_gas_price.get_gas_price(60) == 1125
+        assert geometric_gas_price.get_gas_price(119) == 1125
+        assert geometric_gas_price.get_gas_price(120) == 1266
+        assert geometric_gas_price.get_gas_price(1200) == 2500
+        assert geometric_gas_price.get_gas_price(3000) == 2500
+        assert geometric_gas_price.get_gas_price(1000000) == 2500
+
+    def test_behaves_with_realistic_values(self):
+        # given
+        GWEI = 1000000000
+        geometric_gas_price = GeometricGasPrice(100*GWEI, 10, 1+(0.125*2))
+
+        for seconds in [0,1,10,12,30,60]:
+            print(f"gas price after {seconds} seconds is {geometric_gas_price.get_gas_price(seconds)/GWEI}")
+
+        assert round(geometric_gas_price.get_gas_price(0) / GWEI, 1) == 100.0
+        assert round(geometric_gas_price.get_gas_price(1) / GWEI, 1) == 100.0
+        assert round(geometric_gas_price.get_gas_price(10) / GWEI, 1) == 125.0
+        assert round(geometric_gas_price.get_gas_price(12) / GWEI, 1) == 125.0
+        assert round(geometric_gas_price.get_gas_price(30) / GWEI, 1) == 195.3
+        assert round(geometric_gas_price.get_gas_price(60) / GWEI, 1) == 381.5
+
+    def test_should_require_positive_initial_price(self):
+        with pytest.raises(AssertionError):
+            GeometricGasPrice(0, 60)
+
+        with pytest.raises(AssertionError):
+            GeometricGasPrice(-1, 60)
+
+    def test_should_require_positive_every_secs_value(self):
+        with pytest.raises(AssertionError):
+            GeometricGasPrice(1000, 0)
+
+        with pytest.raises(AssertionError):
+            GeometricGasPrice(1000, -1)
+
+    def test_should_require_positive_coefficient(self):
+        with pytest.raises(AssertionError):
+            GeometricGasPrice(1000, 60, 0)
+
+        with pytest.raises(AssertionError):
+            GeometricGasPrice(1000, 60, -1)
+
+    def test_should_require_positive_max_price_if_provided(self):
+        with pytest.raises(AssertionError):
+            GeometricGasPrice(1000, 60, 1.125, 0)
+
+        with pytest.raises(AssertionError):
+            GeometricGasPrice(1000, 60, 1.125, -1)


### PR DESCRIPTION
`IncreasingGasPrice` is undesirable because it results in a linearly increasing gas price.  The percentage increase becomes progressively smaller over time, resulting in a smaller chance of a transaction being replaced.

`GeometricGasPrice` solves this by implementing incrementing by a percentage, which more naturally reflects the manner in which nodes accept replacement transactions.  The default is set to 12.5%, suitable for most use cases.  The user is only responsible for setting an initial value and a number of seconds.