### PR TITLE
Allow consumer to supply gas limit and submit txs which will fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,14 @@ You can then run all tests with:
 ./test.sh
 ```
 
+By default, `pymaker` will not send a transaction to the chain if gas estimation fails, because this means the 
+transaction would revert.  For testing purposes, it is sometimes useful to send bad transactions to the chain.  To 
+accomplish this, set class variable `gas_estimate_for_bad_txs` in your application.  For example:
+```
+from pymaker import Transact
+Transact.gas_estimate_for_bad_txs = 200000
+```
+
 ## License
 
 See [COPYING](https://github.com/makerdao/pymaker/blob/master/COPYING) file.

--- a/pymaker/__init__.py
+++ b/pymaker/__init__.py
@@ -347,6 +347,7 @@ class Transact:
     """Represents an Ethereum transaction before it gets executed."""
 
     logger = logging.getLogger()
+    gas_estimate_for_bad_txs = None
 
     def __init__(self,
                  origin: Optional[object],
@@ -556,8 +557,12 @@ class Transact:
         try:
             gas_estimate = self.estimated_gas(Address(from_account))
         except:
-            self.logger.warning(f"Transaction {self.name()} will fail, refusing to send ({sys.exc_info()[1]})")
-            return None
+            if Transact.gas_estimate_for_bad_txs:
+                self.logger.warning(f"Transaction {self.name()} will fail, submitting anyway")
+                gas_estimate = Transact.gas_estimate_for_bad_txs
+            else:
+                self.logger.warning(f"Transaction {self.name()} will fail, refusing to send ({sys.exc_info()[1]})")
+                return None
 
         # Get or calculate `gas`. Get `gas_price`, which in fact refers to a gas pricing algorithm.
         gas = self._gas(gas_estimate, **kwargs)


### PR DESCRIPTION
We discussed this last week.  Feature is disabled by default, and most consumers would never enable it.  Documented in the README.