### PR TITLE
recreate filters lost by the node

### DIFF
--- a/pymaker/lifecycle.py
+++ b/pymaker/lifecycle.py
@@ -350,9 +350,14 @@ class Lifecycle:
         def new_block_watch():
             event_filter = self.web3.eth.filter('latest')
             while True:
-                for event in event_filter.get_new_entries():
-                    new_block_callback(event)
-                time.sleep(1)
+                try:
+                    for event in event_filter.get_new_entries():
+                        new_block_callback(event)
+                except ValueError:
+                    self.logger.warning("Node dropped event emitter; recreating latest block filter")
+                    event_filter = self.web3.eth.filter('latest')
+                finally:
+                    time.sleep(1)
 
         if self.block_function:
             self._on_block_callback = AsyncCallback(self.block_function)


### PR DESCRIPTION
A few times a month, keepers log the following error:
```ValueError: {'code': -32000, 'message': 'Filter not found'}```
followed by
```
2020-05-07 19:34:32,000 CRITICAL No new blocks received for 300 seconds, the keeper will terminate
2020-05-07 19:34:32,001 INFO     Shutting down the keeper
```
[This post](https://ethereum.stackexchange.com/questions/60708/ethereum-web3-filter-not-found) explains nodes can lose filters and _web3.py_ doesn't automatically reestablish them.  Lifecycle uses filters to detect new blocks.

This change catches the exception and recreates the filter.  Difficult to integration test because I couldn't find a way to induce the behavior.
