### PR TITLE
Gemjoin6\b5

### DIFF
--- a/pymaker/deployment.py
+++ b/pymaker/deployment.py
@@ -216,7 +216,7 @@ class DssDeployment:
                 else:
                     gem = DSToken(web3, Address(conf[name[1]]))
 
-                if name[1] in ['USDC', 'WBTC']:
+                if name[1] in ['USDC', 'WBTC', 'TUSD']:
                     adapter = GemJoin5(web3, Address(conf[f'MCD_JOIN_{name[0]}']))
                 else:
                     adapter = GemJoin(web3, Address(conf[f'MCD_JOIN_{name[0]}']))

--- a/tests/manual_test_mcd.py
+++ b/tests/manual_test_mcd.py
@@ -43,7 +43,6 @@ collateral_amount = Wad.from_number(0.2)
 dai_amount = Wad.from_number(20.0)
 
 if collateral.gem.balance_of(our_address) > collateral_amount:
-    print(f"collateral.ilk.name={collateral.ilk.name}")
     if run_transactions and collateral.ilk.name.startswith("ETH"):
         # Wrap ETH to produce WETH
         assert collateral.gem.deposit(collateral_amount).transact()

--- a/tests/manual_test_mcd.py
+++ b/tests/manual_test_mcd.py
@@ -17,20 +17,20 @@
 
 import os
 import sys
-from pprint import pprint
 from web3 import Web3, HTTPProvider
 
 from pymaker import Address
-from pymaker.auctions import Flipper, Flapper, Flopper
 from pymaker.deployment import DssDeployment
 from pymaker.keys import register_keys
 from pymaker.numeric import Wad
 
-endpoint_uri = f"{os.environ['SERVER_ETH_RPC_HOST']}:{os.environ['SERVER_ETH_RPC_PORT']}"
-web3 = Web3(HTTPProvider(endpoint_uri=endpoint_uri, request_kwargs={"timeout": 10}))
+web3 = Web3(HTTPProvider(endpoint_uri=os.environ['ETH_RPC_URL'], request_kwargs={"timeout": 10}))
 web3.eth.defaultAccount = sys.argv[1]   # ex: 0x0000000000000000000000000000000aBcdef123
-register_keys(web3, [sys.argv[2]])      # ex: key_file=~keys/default-account.json,pass_file=~keys/default-account.pass
-
+if len(sys.argv) > 2:
+    register_keys(web3, [sys.argv[2]])  # ex: key_file=~keys/default-account.json,pass_file=~keys/default-account.pass
+    run_transactions = True
+else:
+    run_transactions = False
 mcd = DssDeployment.from_node(web3)
 our_address = Address(web3.eth.defaultAccount)
 
@@ -38,32 +38,41 @@ our_address = Address(web3.eth.defaultAccount)
 collateral = mcd.collaterals['ETH-A']
 ilk = collateral.ilk
 
-# This is a safe amount of collateral (as of 2020.03.11) to draw 20 Dai
+# Set an amount of collateral to join and an amount of Dai to draw
 collateral_amount = Wad.from_number(0.2)
+dai_amount = Wad.from_number(20.0)
+
 if collateral.gem.balance_of(our_address) > collateral_amount:
-    collateral.gem.deposit(collateral_amount).transact()
+    print(f"collateral.ilk.name={collateral.ilk.name}")
+    if run_transactions and collateral.ilk.name.startswith("ETH"):
+        # Wrap ETH to produce WETH
+        assert collateral.gem.deposit(collateral_amount).transact()
 
-    # Add collateral and allocate the desired amount of Dai
-    collateral.approve(our_address)
-    assert collateral.adapter.join(our_address, collateral_amount).transact()
-    dai_amount = Wad.from_number(0.153)
-    mcd.vat.frob(ilk, our_address, dink=collateral_amount, dart=Wad(0)).transact()
-    mcd.vat.frob(ilk, our_address, dink=Wad(0), dart=dai_amount).transact()
-    print(f"Dai balance before withdrawal: {mcd.vat.dai(our_address)}")
+    if run_transactions:
+        # Add collateral and allocate the desired amount of Dai
+        collateral.approve(our_address)
+        assert collateral.adapter.join(our_address, collateral_amount).transact()
+        assert mcd.vat.frob(ilk, our_address, dink=collateral_amount, dart=Wad(0)).transact()
+        assert mcd.vat.frob(ilk, our_address, dink=Wad(0), dart=dai_amount).transact()
+    print(f"Urn balance: {mcd.vat.urn(ilk, our_address)}")
+    print(f"Dai balance: {mcd.vat.dai(our_address)}")
 
-    # Mint and withdraw our Dai
-    mcd.approve_dai(our_address)
-    mcd.dai_adapter.exit(our_address, dai_amount).transact()
-    print(f"Dai balance after withdrawal:  {mcd.vat.dai(our_address)}")
+    if run_transactions:
+        # Mint and withdraw our Dai
+        mcd.approve_dai(our_address)
+        assert mcd.dai_adapter.exit(our_address, dai_amount).transact()
+        print(f"Dai balance after withdrawal:  {mcd.vat.dai(our_address)}")
 
-    # Repay (and burn) our Dai
-    assert mcd.dai_adapter.join(our_address, dai_amount).transact()
-    print(f"Dai balance after repayment:   {mcd.vat.dai(our_address)}")
+        # Repay (and burn) our Dai
+        assert mcd.dai_adapter.join(our_address, dai_amount).transact()
+        print(f"Dai balance after repayment:   {mcd.vat.dai(our_address)}")
 
-    # Withdraw our collateral
-    mcd.vat.frob(ilk, our_address, dink=Wad(0), dart=dai_amount*-1).transact()
-    mcd.vat.frob(ilk, our_address, dink=collateral_amount*-1, dart=Wad(0)).transact()
-    collateral.adapter.exit(our_address, collateral_amount).transact()
-    print(f"Dai balance w/o collateral:    {mcd.vat.dai(our_address)}")
+        # Withdraw our collateral; stability fee accumulation may make these revert
+        assert mcd.vat.frob(ilk, our_address, dink=Wad(0), dart=dai_amount*-1).transact()
+        assert mcd.vat.frob(ilk, our_address, dink=collateral_amount*-1, dart=Wad(0)).transact()
+        assert collateral.adapter.exit(our_address, collateral_amount).transact()
+        print(f"Dai balance w/o collateral:    {mcd.vat.dai(our_address)}")
+else:
+    print(f"Not enough {ilk.name} to join to the vat")
 
 print(f"Collateral balance: {mcd.vat.gem(ilk, our_address)}")


### PR DESCRIPTION
This is really just to improve consistency with other coins using newer `GemJoin` contracts.  And to improve the manual test for MCD.  

Since there's no interface change, I didn't see a reason to wrap and add artifacts for `GemJoin6`; it would've just added more cruft to the API.  I'm happy to do so if a gas estimation issue for [this call](https://github.com/makerdao/dss-deploy/blob/master/src/join.sol#L370) ever arises.

Tested on kovan only.