### PR TITLE
Fix compatibility with Python 3.8

### DIFF
--- a/pymaker/sign.py
+++ b/pymaker/sign.py
@@ -42,7 +42,7 @@ def eth_sign(message: bytes, web3: Web3, key=None, in_hexbytes=False, account=No
             pkey = key
 
         start_time = time.time()
-        start_clock = time.clock()
+        start_clock = time.process_time()
         try:
             if in_hexbytes:
                 message_hash = message
@@ -51,7 +51,7 @@ def eth_sign(message: bytes, web3: Web3, key=None, in_hexbytes=False, account=No
             signature = web3.eth.account.signHash(message_hash, private_key=pkey).signature.hex()
         finally:
             end_time = time.time()
-            end_clock = time.clock()
+            end_clock = time.process_time()
 
         logging.debug(f"Local signing took {end_time - start_time:.3f}s time, {end_clock - start_clock:.3f}s clock")
 


### PR DESCRIPTION
This replaces `time.clock` which has been [deprecated](https://docs.python.org/3.6/library/time.html?highlight=process_time#time.clock) since Python 3.3 and has been removed in Python 3.8 with `time.process_time` which is available since Python 3.3.