### PR TITLE
when we call to check for logs, and none exist ensure we return None

### DIFF
--- a/pymaker/zrxv2.py
+++ b/pymaker/zrxv2.py
@@ -287,6 +287,9 @@ class LogFill:
 
             return LogFill(event_data)
 
+        else:
+            return None
+
     def __eq__(self, other):
         assert(isinstance(other, LogFill))
         return self.__dict__ == other.__dict__


### PR DESCRIPTION
Making this change to specifically get rid of IMtoken errors which occur when syncing all trades. If we send a request to a node and the event that we are looking for `LogFill` doesn't exist we don't return from the method. This PR returns None