### PR TITLE
handle case where initial_gas is greater than max_price

### DIFF
--- a/pymaker/gas.py
+++ b/pymaker/gas.py
@@ -162,7 +162,7 @@ class GeometricGasPrice(GasPrice):
         assert (every_secs > 0)
         assert (coefficient > 1)
         if max_price is not None:
-            assert(max_price > 0)
+            assert(max_price >= initial_price)
 
         self.initial_price = initial_price
         self.every_secs = every_secs

--- a/pymaker/gas.py
+++ b/pymaker/gas.py
@@ -172,11 +172,10 @@ class GeometricGasPrice(GasPrice):
     def get_gas_price(self, time_elapsed: int) -> Optional[int]:
         assert(isinstance(time_elapsed, int))
 
-        if time_elapsed < self.every_secs:
-            return self.initial_price
         result = self.initial_price
-        for second in range(math.floor(time_elapsed/self.every_secs)):
-            result *= self.coefficient
+        if time_elapsed >= self.every_secs:
+            for second in range(math.floor(time_elapsed/self.every_secs)):
+                result *= self.coefficient
         if self.max_price is not None:
             result = min(result, self.max_price)
 

--- a/tests/test_gas.py
+++ b/tests/test_gas.py
@@ -164,6 +164,14 @@ class TestGeometricGasPrice:
         assert geometric_gas_price.get_gas_price(3000) == 2500
         assert geometric_gas_price.get_gas_price(1000000) == 2500
 
+        # given
+        geometric_gas_price = GeometricGasPrice(6000, 30, 1.125, 5000)
+
+        # expect
+        assert geometric_gas_price.get_gas_price(0) == 5000
+        assert geometric_gas_price.get_gas_price(31) == 5000
+        assert geometric_gas_price.get_gas_price(62) == 5000
+
     def test_behaves_with_realistic_values(self):
         # given
         GWEI = 1000000000

--- a/tests/test_gas.py
+++ b/tests/test_gas.py
@@ -164,14 +164,6 @@ class TestGeometricGasPrice:
         assert geometric_gas_price.get_gas_price(3000) == 2500
         assert geometric_gas_price.get_gas_price(1000000) == 2500
 
-        # given
-        geometric_gas_price = GeometricGasPrice(6000, 30, 1.125, 5000)
-
-        # expect
-        assert geometric_gas_price.get_gas_price(0) == 5000
-        assert geometric_gas_price.get_gas_price(31) == 5000
-        assert geometric_gas_price.get_gas_price(62) == 5000
-
     def test_behaves_with_realistic_values(self):
         # given
         GWEI = 1000000000
@@ -217,3 +209,7 @@ class TestGeometricGasPrice:
 
         with pytest.raises(AssertionError):
             GeometricGasPrice(1000, 60, 1.125, -1)
+
+    def test_max_price_should_exceed_initial_price(self):
+        with pytest.raises(AssertionError):
+            GeometricGasPrice(6000, 30, 2.25, 5000)


### PR DESCRIPTION
Found this corner case when working on `auction-keeper` gas changes.