### PR TITLE
Improve behavior when the node's block filter encounters a block newer than "current block"

### DIFF
--- a/pymaker/lifecycle.py
+++ b/pymaker/lifecycle.py
@@ -328,7 +328,7 @@ class Lifecycle:
             block_number = block['number']
             if not self.web3.eth.syncing:
                 max_block_number = self.web3.eth.blockNumber
-                if block_number == max_block_number:
+                if block_number >= max_block_number:
                     def on_start():
                         self.logger.debug(f"Processing block #{block_number} ({block_hash.hex()})")
 

--- a/tests/manual_test_node.py
+++ b/tests/manual_test_node.py
@@ -40,8 +40,11 @@ if len(sys.argv) > 3:
     register_keys(web3, [sys.argv[3]])      # ex: key_file=~keys/default-account.json,pass_file=~keys/default-account.pass
     our_address = Address(web3.eth.defaultAccount)
     run_transactions = True
-else:
+elif len(sys.argv) > 2:
     our_address = Address(sys.argv[2])
+    run_transactions = False
+else:
+    our_address = None
     run_transactions = False
 
 mcd = DssDeployment.from_node(web3)
@@ -70,8 +73,9 @@ class TestApp:
             self.joined += self.amount
         else:
             logging.info(f"Found block {web3.eth.blockNumber}")
-        logging.info(f"Urn balance is {mcd.vat.gem(ilk, our_address)} {ilk.name}")
-        self.request_history()
+        if our_address:
+            logging.info(f"Urn balance is {mcd.vat.gem(ilk, our_address)} {ilk.name}")
+        # self.request_history()
 
     def request_history(self):
         logs = mcd.vat.past_frobs(web3.eth.blockNumber - past_blocks)

--- a/tests/manual_test_node.py
+++ b/tests/manual_test_node.py
@@ -72,7 +72,7 @@ class TestApp:
             assert collateral.adapter.join(our_address, self.amount).transact()
             self.joined += self.amount
         else:
-            logging.info(f"Found block {web3.eth.blockNumber}")
+            logging.info(f"Found block; web3.eth.blockNumber={web3.eth.blockNumber}")
         if our_address:
             logging.info(f"Urn balance is {mcd.vat.gem(ilk, our_address)} {ilk.name}")
         # self.request_history()


### PR DESCRIPTION
I'm letting Travis run the unit tests.  Also improved the manual node test to not require an address.