### PR TITLE
Implement a serial-incrementing nonce for third-party node providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,12 @@ As such, certain JSON-RPC calls in `__init__.py` may not function properly.
  response from the websocket, breaking some core `pymaker` functionality in `Lifecycle` and `Transact` classes.
  * When using an **Infura** node to pull event logs, ensure your requests are batched into a small enough chunks such 
  that no more than 10,000 results will be returned for each request.
- * Asynchronous submission of simultaneous transactions will not work on **Infura** due to lack of  
- [parity_nextNonce](https://community.infura.io/t/wrong-nonce-number-in-eth-gettransactioncount/357/14) support. 
+ * Asynchronous submission of simultaneous transactions often doesn't work on third-party node providers because RPC 
+ calls to `parity_nextNonce` and `getTransactionCount` are inappropriately proxied, cached, or just plain not 
+ supported.  To remedy this, a serial-incrementing nonce is used for these providers' URLs.  The downside to a serial-
+ incrementing nonce is that transactions for the same account from another wallet or keeper will bring the next nonce 
+ out-of-alignment, and the application using `pymaker` will need to be restarted to recover.
+ * Recovery of pending transactions does not work on certain third-party node providers.
 
 
 ## Available APIs

--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ As such, certain JSON-RPC calls in `__init__.py` may not function properly.
  * Asynchronous submission of simultaneous transactions often doesn't work on third-party node providers because RPC 
  calls to `parity_nextNonce` and `getTransactionCount` are inappropriately proxied, cached, or just plain not 
  supported.  To remedy this, a serial-incrementing nonce is used for these providers' URLs.  The downside to a serial-
- incrementing nonce is that transactions for the same account from another wallet or keeper will bring the next nonce 
- out-of-alignment, and the application using `pymaker` will need to be restarted to recover.
+ incrementing nonce is that transactions submitted for the same account from another wallet or keeper will bring the 
+ next nonce out-of-alignment, causing transaction failures or unexpected replacements.  To work around this, stop the 
+ application, wait for pending transactions for the account to be mined, and then restart the application.  
  * Recovery of pending transactions does not work on certain third-party node providers.
 
 

--- a/pymaker/__init__.py
+++ b/pymaker/__init__.py
@@ -717,7 +717,9 @@ class Transact:
                             elif nonce_calculation == NonceCalculation.TX_COUNT:
                                 self.nonce = self.web3.eth.getTransactionCount(from_account, block_identifier='pending')
                             elif nonce_calculation == NonceCalculation.SERIAL:
-                                self.nonce = next_nonce[from_account]
+                                tx_count = self.web3.eth.getTransactionCount(from_account, block_identifier='pending')
+                                next_serial = next_nonce[from_account]
+                                self.nonce = max(tx_count, next_serial)
                             next_nonce[from_account] = self.nonce + 1
 
                         # Trap replacement while original is holding the lock awaiting nonce assignment

--- a/pymaker/__init__.py
+++ b/pymaker/__init__.py
@@ -45,7 +45,8 @@ from pymaker.numeric import Wad
 from pymaker.util import synchronize, bytes_to_hexstring, is_contract_at
 
 filter_threads = []
-node_is_parity = WeakKeyDictionary()
+nonce_calc = WeakKeyDictionary()
+next_nonce = {}
 transaction_lock = Lock()
 logger = logging.getLogger()
 
@@ -63,15 +64,28 @@ def web3_via_http(endpoint_uri: str, timeout=60, http_pool_size=20):
     return Web3(HTTPProvider(endpoint_uri=endpoint_uri, request_kwargs={"timeout": timeout}, session=session))
 
 
-def _is_parity(web3: Web3) -> bool:
+class NonceCalculation(Enum):
+    TX_COUNT = auto()
+    PARITY_NEXTNONCE = auto()
+    SERIAL = auto()
+
+
+def _get_nonce_calc(web3: Web3) -> NonceCalculation:
     assert isinstance(web3, Web3)
-    global node_is_parity
-    if web3 not in node_is_parity:
-        logger.debug(f"node clientVersion={web3.clientVersion}")
-        is_infura = "infura" in web3.manager.provider.endpoint_uri
+    global nonce_calc
+    if web3 not in nonce_calc:
+        providers_without_nonce_calculation = ['infura', 'quiknode']
+        requires_serial_nonce = any(provider in web3.manager.provider.endpoint_uri for provider in
+                                    providers_without_nonce_calculation)
         is_parity = "parity" in web3.clientVersion.lower() or "openethereum" in web3.clientVersion.lower()
-        node_is_parity[web3] = is_parity and not is_infura
-    return node_is_parity[web3]
+        if requires_serial_nonce:
+            nonce_calc[web3] = NonceCalculation.SERIAL
+        elif is_parity:
+            nonce_calc[web3] = NonceCalculation.PARITY_NEXTNONCE
+        else:
+            nonce_calc[web3] = NonceCalculation.TX_COUNT
+        logger.debug(f"node clientVersion={web3.clientVersion}, will use {nonce_calc[web3]}")
+    return nonce_calc[web3]
 
 
 def register_filter_thread(filter_thread):
@@ -379,7 +393,7 @@ def get_pending_transactions(web3: Web3, address: Address = None) -> list:
         address = Address(web3.eth.defaultAccount)
 
     # Get the list of pending transactions and their details from specified sources
-    if _is_parity(web3):
+    if _get_nonce_calc(web3) == NonceCalculation.PARITY_NEXTNONCE:
         items = web3.manager.request_blocking("parity_pendingTransactions", [])
         items = filter(lambda item: item['from'].lower() == address.address.lower(), items)
         items = filter(lambda item: item['blockNumber'] is None, items)
@@ -592,13 +606,16 @@ class Transact:
             invocation was successful, or `None` if it failed.
         """
 
+        global next_nonce
         self.initial_time = time.time()
         unknown_kwargs = set(kwargs.keys()) - {'from_address', 'replace', 'gas', 'gas_buffer', 'gas_price'}
         if len(unknown_kwargs) > 0:
-            raise Exception(f"Unknown kwargs: {unknown_kwargs}")
+            raise ValueError(f"Unknown kwargs: {unknown_kwargs}")
 
-        # Get the from account.
+        # Get the from account; initialize the first nonce for the account.
         from_account = kwargs['from_address'].address if ('from_address' in kwargs) else self.web3.eth.defaultAccount
+        if not next_nonce or from_account not in next_nonce:
+            next_nonce[from_account] = self.web3.eth.getTransactionCount(from_account, block_identifier='pending')
 
         # First we try to estimate the gas usage of the transaction. If gas estimation fails
         # it means there is no point in sending the transaction, thus we fail instantly and
@@ -694,10 +711,14 @@ class Transact:
                     # We need the lock in order to not try to send two transactions with the same nonce.
                     with transaction_lock:
                         if self.nonce is None:
-                            if _is_parity(self.web3):
+                            nonce_calculation = _get_nonce_calc(self.web3)
+                            if nonce_calculation == NonceCalculation.PARITY_NEXTNONCE:
                                 self.nonce = int(self.web3.manager.request_blocking("parity_nextNonce", [from_account]), 16)
-                            else:
+                            elif nonce_calculation == NonceCalculation.TX_COUNT:
                                 self.nonce = self.web3.eth.getTransactionCount(from_account, block_identifier='pending')
+                            elif nonce_calculation == NonceCalculation.SERIAL:
+                                self.nonce = next_nonce[from_account]
+                            next_nonce[from_account] = self.nonce + 1
 
                         # Trap replacement while original is holding the lock awaiting nonce assignment
                         if self.replaced:

--- a/tests/manual_test_async_tx.py
+++ b/tests/manual_test_async_tx.py
@@ -45,8 +45,8 @@ our_address = Address(web3.eth.defaultAccount)
 weth = DssDeployment.from_node(web3).collaterals['ETH-A'].gem
 
 GWEI = 1000000000
-slow_gas = GeometricGasPrice(initial_price=int(0.8 * GWEI), every_secs=30, max_price=2000 * GWEI)
-fast_gas = GeometricGasPrice(initial_price=int(1.1 * GWEI), every_secs=30, max_price=2000 * GWEI)
+slow_gas = GeometricGasPrice(initial_price=int(44 * GWEI), every_secs=42, max_price=200 * GWEI)
+fast_gas = GeometricGasPrice(initial_price=int(66 * GWEI), every_secs=42, max_price=200 * GWEI)
 
 
 class TestApp:
@@ -72,7 +72,7 @@ class TestApp:
         self._run_future(weth.deposit(Wad(3)).transact_async(gas_price=fast_gas))
         self._run_future(weth.deposit(Wad(5)).transact_async(gas_price=fast_gas))
         self._run_future(weth.deposit(Wad(7)).transact_async(gas_price=fast_gas))
-        time.sleep(3)
+        time.sleep(33)
 
     def shutdown(self):
         balance = weth.balance_of(our_address)

--- a/tests/manual_test_async_tx.py
+++ b/tests/manual_test_async_tx.py
@@ -63,23 +63,25 @@ class TestApp:
 
         second_tx = weth.deposit(Wad(6))
         logging.info(f"Replacing first TX with legitimate gas price")
-        second_tx.transact(replace=first_tx)
+        second_tx.transact(replace=first_tx, gas_price=fast_gas)
 
         assert first_tx.replaced
 
     def test_simultaneous(self):
         self._run_future(weth.deposit(Wad(1)).transact_async(gas_price=fast_gas))
+        self._run_future(weth.deposit(Wad(3)).transact_async(gas_price=fast_gas))
         self._run_future(weth.deposit(Wad(5)).transact_async(gas_price=fast_gas))
-        asyncio.sleep(6)
+        self._run_future(weth.deposit(Wad(7)).transact_async(gas_price=fast_gas))
+        time.sleep(3)
 
     def shutdown(self):
         balance = weth.balance_of(our_address)
         if Wad(0) < balance < Wad(100):  # this account's tiny WETH balance came from this test
             logging.info(f"Unwrapping {balance} WETH")
             assert weth.withdraw(balance).transact(gas_price=fast_gas)
-        elif balance >= Wad(12):  # user already had a balance, so unwrap what a successful test would have consumed
+        elif balance >= Wad(22):  # user already had a balance, so unwrap what a successful test would have consumed
             logging.info(f"Unwrapping 12 WETH")
-            assert weth.withdraw(Wad(12)).transact(gas_price=fast_gas)
+            assert weth.withdraw(Wad(22)).transact(gas_price=fast_gas)
 
     @staticmethod
     def _run_future(future):

--- a/tests/manual_test_async_tx.py
+++ b/tests/manual_test_async_tx.py
@@ -45,8 +45,8 @@ our_address = Address(web3.eth.defaultAccount)
 weth = DssDeployment.from_node(web3).collaterals['ETH-A'].gem
 
 GWEI = 1000000000
-slow_gas = GeometricGasPrice(initial_price=int(44 * GWEI), every_secs=42, max_price=200 * GWEI)
-fast_gas = GeometricGasPrice(initial_price=int(66 * GWEI), every_secs=42, max_price=200 * GWEI)
+slow_gas = GeometricGasPrice(initial_price=int(15 * GWEI), every_secs=42, max_price=200 * GWEI)
+fast_gas = GeometricGasPrice(initial_price=int(30 * GWEI), every_secs=42, max_price=200 * GWEI)
 
 
 class TestApp:


### PR DESCRIPTION
The old implementation merely checked if a node was Parity, so it could use `parity_nextNonce` and used `getTransactionCount("pending")` for any non-Parity node.  The new implementation offers a third option, which calls `getTransactionCount` once upon submission of the first transaction, and then atomically increments the nonce for each successive call.  Documented tradeoffs of this approach in the `README`.