### PR TITLE
add support for Univ2LpOracle.sol

### DIFF
--- a/pymaker/deployment.py
+++ b/pymaker/deployment.py
@@ -35,7 +35,7 @@ from pymaker.gas import DefaultGasPrice
 from pymaker.governance import DSPause, DSChief
 from pymaker.numeric import Wad, Ray
 from pymaker.oasis import MatchingMarket
-from pymaker.oracles import OSM
+from pymaker.oracles import OSM, Univ2LpOSM
 from pymaker.sai import Tub, Tap, Top, Vox
 from pymaker.shutdown import ShutdownModule, End
 from pymaker.token import DSToken, DSEthToken
@@ -230,7 +230,10 @@ class DssDeployment:
                 if network == "testnet":
                     pip = DSValue(web3, pip_address)
                 else:
-                    pip = OSM(web3, pip_address)
+                    if name[1].startswith('UNIV2'):
+                        pip = Univ2LpOSM(web3, pip_address)
+                    else:
+                        pip = OSM(web3, pip_address)
 
                 collateral = Collateral(ilk=ilk, gem=gem, adapter=adapter,
                                         flipper=Flipper(web3, Address(conf[f'MCD_FLIP_{name[0]}'])),

--- a/pymaker/oracles.py
+++ b/pymaker/oracles.py
@@ -62,3 +62,20 @@ class OSM(Contract):
 
     def __repr__(self):
         return f"OSM('{self.address}')"
+
+
+class Univ2LpOSM(OSM):
+    """A custom `OSM` contract for Uniswap LP tokens
+
+    You can find the source code of the `OSM` contract here:
+    <https://github.com/makerdao/univ2-lp-oracle>.
+    """
+
+    def __init__(self, web3: Web3, address: Address):
+        super().__init__(web3, address)
+
+    def peek(self) -> Wad:
+        return Wad(self._extract_price(6))
+
+    def peep(self) -> Wad:
+        return Wad(self._extract_price(7))

--- a/tests/manual_test_mcd.py
+++ b/tests/manual_test_mcd.py
@@ -40,7 +40,7 @@ mcd = DssDeployment.from_node(web3)
 
 # Print a list of collaterals available for this deployment of MCD
 for collateral in mcd.collaterals.values():
-    osm = OSM(web3, collateral.pip.address)
+    osm: OSM = collateral.pip
     print(f"Found {collateral.ilk.name:>15} - {collateral.gem.name():<21} with {collateral.adapter.dec():>2} decimals " 
           f"with oracle price {float(osm.peek())}")
 


### PR DESCRIPTION
It's assumed this will be used for other UNIV2 tokens as well.  Tested on kovan (legit price) and mainnet (0 price untill spell is cast).