### PR TITLE
Univ3 pyexchange client changes

### DIFF
--- a/pymaker/__init__.py
+++ b/pymaker/__init__.py
@@ -37,6 +37,7 @@ from web3._utils.contracts import get_function_info, encode_abi
 from web3._utils.events import get_event_data
 from web3.exceptions import TransactionNotFound
 from web3.middleware import geth_poa_middleware
+from web3.exceptions import LogTopicError, TransactionNotFound
 
 from eth_abi.codec import ABICodec
 from eth_abi.registry import registry as default_registry
@@ -286,6 +287,21 @@ class Calldata:
 
         return cls(calldata)
 
+    @classmethod
+    def from_contract_abi(cls, web3: Web3, fn_sign: str, fn_args: list, contract_abi):
+        """ Create a `Calldata` according to the given contract abi """
+        assert isinstance(web3, Web3)
+        assert isinstance(fn_sign, str)
+        assert isinstance(fn_args, list)
+
+        fn_split = re.split('[(),]', fn_sign)
+        fn_name = fn_split[0]
+
+        fn_abi, fn_selector, fn_arguments = get_function_info(fn_name, abi_codec=web3.codec, contract_abi=contract_abi, args=fn_args)
+        calldata = encode_abi(web3, fn_abi, fn_arguments, fn_selector)
+
+        return cls(calldata)
+
     def as_bytes(self) -> bytes:
         """Return the calldata as a byte array."""
         return bytes.fromhex(self.value.replace('0x', ''))
@@ -352,11 +368,15 @@ class Receipt:
                         from pymaker.token import ERC20Token
                         transfer_abi = [abi for abi in ERC20Token.abi if abi.get('name') == 'Transfer'][0]
                         codec = ABICodec(default_registry)
-                        event_data = get_event_data(codec, transfer_abi, receipt_log)
-                        self.transfers.append(Transfer(token_address=Address(event_data['address']),
-                                                       from_address=Address(event_data['args']['from']),
-                                                       to_address=Address(event_data['args']['to']),
-                                                       value=Wad(event_data['args']['value'])))
+                        try:
+                            event_data = get_event_data(codec, transfer_abi, receipt_log)
+                            self.transfers.append(Transfer(token_address=Address(event_data['address']),
+                                                           from_address=Address(event_data['args']['from']),
+                                                           to_address=Address(event_data['args']['to']),
+                                                           value=Wad(event_data['args']['value'])))
+                        # UniV3 Mint logIndex: 3 has an NFT mint of 1, from null, to a given address, but only 2 types (address, address)
+                        except LogTopicError:
+                            continue
 
                     # $ seth keccak $(seth --from-ascii "Mint(address,uint256)")
                     # 0x0f6798a560793a54c3bcfe86a93cde1e73087d944c0ea20544137d4121396885

--- a/tests/test_auctions.py
+++ b/tests/test_auctions.py
@@ -44,7 +44,7 @@ def create_surplus(mcd: DssDeployment, flapper: Flapper, deployment_address: Add
         assert collateral.adapter.join(deployment_address, ink).transact(
             from_address=deployment_address)
         # CAUTION: dart needs to be adjusted over time to keep tests happy
-        frob(mcd, collateral, deployment_address, dink=ink, dart=Wad.from_number(7500))
+        frob(mcd, collateral, deployment_address, dink=ink, dart=Wad.from_number(3000))
         assert mcd.jug.drip(collateral.ilk).transact(from_address=deployment_address)
         joy = mcd.vat.dai(mcd.vow.address)
         # total surplus > total debt + surplus auction lot size + surplus buffer

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -20,10 +20,12 @@ from hexbytes import HexBytes
 from web3 import HTTPProvider, Web3
 from web3._utils.request import _get_session
 
-from pymaker import Address, Calldata, Receipt, Transfer, web3_via_http
+from pymaker import Address, Calldata, Contract, Receipt, Transfer, web3_via_http
 from pymaker.numeric import Wad
 from pymaker.util import eth_balance
 from tests.helpers import is_hashable
+
+test_abi = Contract._load_abi(__name__, 'abi/GemMock.abi')
 
 
 class TestConnect:
@@ -180,6 +182,21 @@ class TestCalldata:
 
         # expect
         assert calldata2a == calldata2b
+
+    def test_from_contract_abi(self, web3):
+        # given
+        calldata1a = Calldata('0xa9059cbb'  # function 4byte signature
+                              '00000000000000000000000011223344556600000000000000000000000000ff'
+                              '000000000000000000000000000000000000000000000000000000000000007b')
+
+        calldata1b = Calldata.from_contract_abi(web3,
+                                             'transfer(address,uint256)',
+                                             ['0x11223344556600000000000000000000000000ff', 123],
+                                             test_abi)
+
+        # expect
+        assert calldata1a == calldata1b
+
 
 class TestReceipt:
     @pytest.fixture()


### PR DESCRIPTION
This PR adds support for generating Calldata from contract_abi, as well as handling erc721 minting transfer event errors in receipt. Mint emits a `Transfer` event which collides with the existing pymaker.receipt expectations.                                                                                                 
